### PR TITLE
Allow users to selectively flash logical partitions

### DIFF
--- a/Linux/flash_all.sh
+++ b/Linux/flash_all.sh
@@ -50,18 +50,25 @@ for i in abl aop aop_config bluetooth cpucp devcfg dsp featenabler hyp imagefv k
     sudo fastboot flash $SLOT $i $i.img
 done
 
-echo "###############################"
-echo "# FLASHING LOGICAL PARTITIONS #"
-echo "###############################"
-for i in system system_ext product vendor vendor_dlkm odm; do
-    for s in a b; do
-        sudo fastboot delete-logical-partition ${i}_${s}-cow
-        sudo fastboot delete-logical-partition ${i}_${s}
-        sudo fastboot create-logical-partition ${i}_${s} 1
-    done
+echo "Flash logical partition images?"
+echo "If you're about to install a custom ROM that distributes its own logical partitions, say N."
+read -p "If unsure, say Y. (Y/N) " LOGICAL_RESP
+case $LOGICAL_RESP in
+    [yY] )
+        echo "###############################"
+        echo "# FLASHING LOGICAL PARTITIONS #"
+        echo "###############################"
+        for i in system system_ext product vendor vendor_dlkm odm; do
+            for s in a b; do
+                sudo fastboot delete-logical-partition ${i}_${s}-cow
+                sudo fastboot delete-logical-partition ${i}_${s}
+                sudo fastboot create-logical-partition ${i}_${s} 1
+            done
 
-    sudo fastboot flash $i $i.img
-done
+            sudo fastboot flash $i $i.img
+        done
+        ;;
+esac
 
 echo "#############"
 echo "# REBOOTING #"

--- a/Windows/flash_all.bat
+++ b/Windows/flash_all.bat
@@ -49,17 +49,22 @@ for %%i in (abl aop aop_config bluetooth cpucp devcfg dsp featenabler hyp imagef
     fastboot flash %slot% %%i %%i.img
 )
 
-echo ###############################
-echo # FLASHING LOGICAL PARTITIONS #
-echo ###############################
-for %%i in (system system_ext product vendor vendor_dlkm odm) do (
-    for %%s in (a b) do (
-        fastboot delete-logical-partition %%i_%%s-cow
-        fastboot delete-logical-partition %%i_%%s
-        fastboot create-logical-partition %%i_%%s 1
-    )
+echo Flash logical partition images?
+echo If you're about to install a custom ROM that distributes its own logical partitions, say N.
+choice /m "If unsure, say Y."
+if %errorlevel% equ 1 (
+    echo ###############################
+    echo # FLASHING LOGICAL PARTITIONS #
+    echo ###############################
+    for %%i in (system system_ext product vendor vendor_dlkm odm) do (
+        for %%s in (a b) do (
+            fastboot delete-logical-partition %%i_%%s-cow
+            fastboot delete-logical-partition %%i_%%s
+            fastboot create-logical-partition %%i_%%s 1
+        )
 
-    fastboot flash %%i %%i.img
+        fastboot flash %%i %%i.img
+    )
 )
 
 echo #############


### PR DESCRIPTION
I'm about to tell NothingMuchROM users to directly use this script, and they can skip logical partitions flashes entirely as I ship them myself.

I think this can come in handy with other custom ROMs as well, if they don't want to ship firmware directly in their OTA zip.