### PR TITLE
Fix multiimg* image names

### DIFF
--- a/Linux/flash_all.sh
+++ b/Linux/flash_all.sh
@@ -46,7 +46,7 @@ sudo fastboot reboot fastboot
 echo  "#####################"
 echo  "# FLASHING FIRMWARE #"
 echo  "#####################"
-for i in abl aop aop_config bluetooth cpucp devcfg dsp featenabler hyp imagefv keymaster modem multoem multqti qupfw qweslicstore shrm tz uefi uefisecapp vbmeta vbmeta_system vbmeta_vendor xbl xbl_config xbl_ramdump; do
+for i in abl aop aop_config bluetooth cpucp devcfg dsp featenabler hyp imagefv keymaster modem multiimgoem multiimgqti qupfw qweslicstore shrm tz uefi uefisecapp vbmeta vbmeta_system vbmeta_vendor xbl xbl_config xbl_ramdump; do
     sudo fastboot flash $SLOT $i $i.img
 done
 

--- a/Windows/flash_all.bat
+++ b/Windows/flash_all.bat
@@ -45,7 +45,7 @@ fastboot reboot fastboot
 echo #####################
 echo # FLASHING FIRMWARE #
 echo #####################
-for %%i in (abl aop aop_config bluetooth cpucp devcfg dsp featenabler hyp imagefv keymaster modem multoem multqti qupfw qweslicstore shrm tz uefi uefisecapp vbmeta vbmeta_system vbmeta_vendor xbl xbl_config xbl_ramdump) do (
+for %%i in (abl aop aop_config bluetooth cpucp devcfg dsp featenabler hyp imagefv keymaster modem multiimgoem multiimgqti qupfw qweslicstore shrm tz uefi uefisecapp vbmeta vbmeta_system vbmeta_vendor xbl xbl_config xbl_ramdump) do (
     fastboot flash %slot% %%i %%i.img
 )
 


### PR DESCRIPTION
Previous commit wrongfully truncated multiimg to mult due to a sed syntax error during list generation.

Fix it.

Fixes: 52748a207690 ("vbmeta partitions are not logical")